### PR TITLE
Required cmake 2.8.7 instead of 2.8.9

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 project(luna-next)
 
-cmake_minimum_required(VERSION 2.8.9)
+cmake_minimum_required(VERSION 2.8.7)
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_AUTOMOC ON)


### PR DESCRIPTION
OE danny only ships 2.8.7 and that is our baseline.

Signed-off-by: Simon Busch morphis@gravedo.de
