### PR TITLE
Fixes for compatibility with Qt 5.0.2

### DIFF
--- a/src/compositor/qml/CardView/CardView.qml
+++ b/src/compositor/qml/CardView/CardView.qml
@@ -40,7 +40,7 @@ Item {
     }
 
     function addCard(window) {
-        listCardsModel.append({"window": window})
+        listCardsModel.append({"window": window});
     }
 
     function removeWindow(window) {

--- a/src/compositor/qml/Compositor/DummyWindow.qml
+++ b/src/compositor/qml/Compositor/DummyWindow.qml
@@ -1,5 +1,4 @@
 import QtQuick 2.0
-import QtQuick.Controls 1.0
 
 // this should be a plugin import
 import "compositor.js" as CompositorLogic
@@ -18,25 +17,33 @@ Item {
         }
 
         Column {
-            Button {
+            Text {
                 text: "Current mode: " + (dummyWindow.parent?dummyWindow.parent.state:"undefined")
 
-                onClicked: {
-                    var currentState = CompositorLogic.getAppWindowState(dummyWindow);
-                    // switch to the next state
-                    currentState = (currentState+1) % 3;
-                    CompositorLogic.setAppWindowState(dummyWindow, currentState);
+                MouseArea {
+                    anchors.fill: parent;
+
+                    onClicked: {
+                        var currentState = CompositorLogic.getAppWindowState(dummyWindow);
+                        // switch to the next state
+                        currentState = (currentState+1) % 3;
+                        CompositorLogic.setAppWindowState(dummyWindow, currentState);
+                    }
                 }
             }
-            Button {
+            Text {
                 text: "Add notification"
 
-                onClicked: {
-                    var newNotif = {
-                        "icon": "../GestureArea/glow.png",
-                        "content": "this is a new notification from DummyWindow"
-                    };
-                    CompositorLogic.addNotification(newNotif);
+                MouseArea {
+                    anchors.fill: parent;
+
+                    onClicked: {
+                        var newNotif = {
+                            "icon": "../GestureArea/glow.png",
+                            "content": "this is a new notification from DummyWindow"
+                        };
+                        CompositorLogic.addNotification(newNotif);
+                    }
                 }
             }
         }

--- a/src/compositor/qml/Compositor/compositor.js
+++ b/src/compositor/qml/Compositor/compositor.js
@@ -7,6 +7,8 @@ var windowList = null;
 // add app window window to the compositor
 function addWindow(appWindow)
 {
+    if(!appWindow) return null;
+
     if (windowList == null)
         windowList = new Array(0);
 

--- a/src/compositor/qml/LaunchBar/LaunchBar.qml
+++ b/src/compositor/qml/LaunchBar/LaunchBar.qml
@@ -1,5 +1,5 @@
 import QtQuick 2.0
-import QtQuick.Layouts 1.0
+// import QtQuick.Layouts 1.0 // Note: Qt 5.1 only
 
 Item {
     id: launchBarDisplay
@@ -32,21 +32,24 @@ Item {
         }
     }
 
-    RowLayout {
+    GridView {
         id: launcherRow
 
         anchors.fill: launchBarDisplay
+        cellWidth : parent.width/4
+        cellHeight : parent.height
 
-        Repeater {
-            model: launcherListModel
-            delegate: Image {
+        model: launcherListModel
+        delegate: Item {
+            width: launcherRow.cellWidth;
+            height: launcherRow.cellHeight
+
+            Image {
                 id: launcherIcon
                 fillMode: Image.PreserveAspectFit
+                anchors.centerIn: parent.Center
                 height: parent.height
                 source: icon
-
-                Layout.fillWidth: true
-                Layout.alignment: Qt.AlignCenter
 
                 MouseArea {
                     anchors.fill: parent

--- a/src/compositor/qml/NotificationArea/NotificationsContainer.qml
+++ b/src/compositor/qml/NotificationArea/NotificationsContainer.qml
@@ -12,20 +12,12 @@ Rectangle {
 
     color: "black"
     opacity: 0.8
-    state: "minimized"
+    state: "closed"
 
     property alias notificationArea: notificationsModel
 
     ListModel {
         id: notificationsModel
-        ListElement {
-            icon: "../GestureArea/glow.png"
-            htmlContent: "full content"
-        }
-        ListElement {
-            icon: "../GestureArea/glow.png"
-            htmlContent: "full content2"
-        }
     }
 
     function addNotification(notif) {


### PR DESCRIPTION
- Avoid using the Layout QML module
  - Avoid using QML widgets (pushbutton, etc)

Signed-off-by: Christophe Chapuis chris.chapuis@gmail.com
