### PR TITLE
Make FPS counter only visible when settings option is enabled

### DIFF
--- a/src/compositor/qml/main.qml
+++ b/src/compositor/qml/main.qml
@@ -71,6 +71,8 @@ Compositor.WindowManager {
     Utils.FpsCounter {
         id: fpsCounter
 
+        visible: Settings.displayFps
+
         anchors.top: parent.top
         anchors.left: parent.left
 


### PR DESCRIPTION
Signed-off-by: Simon Busch morphis@gravedo.de
