### PR TITLE
Implement simple cache for service handles

### DIFF
--- a/plugins/lunaserviceadapter.h
+++ b/plugins/lunaserviceadapter.h
@@ -63,6 +63,7 @@ class LunaServiceAdapter : public QObject,
 
 public:
     LunaServiceAdapter(QObject *parent = 0);
+    virtual ~LunaServiceAdapter();
 
     void classBegin();
     void componentComplete();


### PR DESCRIPTION
- reusing already existing service handles for multiply instances of the
  LunaServiceAdapter component with the same service name makes sense in order to limit
  the number of used l2 connections

Signed-off-by: Simon Busch morphis@gravedo.de
