### PR TITLE
Don't set specific environment settings but read them from confiuration ...

### DIFF
--- a/files/systemd/luna-next.service
+++ b/files/systemd/luna-next.service
@@ -4,7 +4,8 @@ After=webos-base.target
 
 [Service]
 Type=notify
-ExecStart=/usr/sbin/luna-next --systemd
+EnvironmentFile=-/etc/luna-next/environment.conf
+ExecStart=/usr/sbin/luna-next $LUNA_NEXT_OPTIONS --systemd
 Restart=always
 
 [Install]

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -31,15 +31,6 @@
 
 int main(int argc, char *argv[])
 {
-    if (!qgetenv("DISPLAY").isEmpty())
-        setenv("QT_QPA_PLATFORM", "xcb", 0);
-    else {
-        setenv("EGL_PLATFORM", "fbdev", 0);
-        setenv("QT_QPA_PLATFORM", "eglfs", 0);
-        setenv("QT_COMPOSITOR_NEGATE_INVERTED_Y", "1", 0);
-        setenv("QT_QPA_EGLFS_HIDECURSOR", "1", 0);
-    }
-
     // preload all settings for later use
     Settings::LunaSettings();
 


### PR DESCRIPTION
...on startup

This makes us more flexible to run in different environments without hardcoding any
specific configuration.

Signed-off-by: Simon Busch morphis@gravedo.de
