### PR TITLE
CompositorWindow: replace "id" property with "winId", to distinguish fro...

### DIFF
--- a/plugins/compositor/compositor.cpp
+++ b/plugins/compositor/compositor.cpp
@@ -53,9 +53,9 @@ void Compositor::clearKeyboardFocus()
     defaultInputDevice()->setKeyboardFocus(0);
 }
 
-void Compositor::closeWindowWithId(int id)
+void Compositor::closeWindowWithId(int winId)
 {
-    CompositorWindow *window = mWindows.value(id, 0);
+    CompositorWindow *window = mWindows.value(winId, 0);
     if (window) {
         if (window->surface() && window->checkIsWebAppMgr())
             window->surface()->destroySurface();
@@ -103,7 +103,7 @@ void Compositor::surfaceAboutToBeDestroyed(QWaylandSurface *surface)
         setFullscreenSurface(0);
 
     if (window) {
-        mWindows.remove(window->id());
+        mWindows.remove(window->winId());
         emit windowRemoved(QVariant::fromValue(static_cast<QQuickItem*>(window)));
 
         window->setClosed(true);

--- a/plugins/compositor/compositor.h
+++ b/plugins/compositor/compositor.h
@@ -47,7 +47,7 @@ public:
     QWaylandSurface *fullscreenSurface() const { return mFullscreenSurface; }
 
     Q_INVOKABLE void clearKeyboardFocus();
-    Q_INVOKABLE void closeWindowWithId(int id);
+    Q_INVOKABLE void closeWindowWithId(int winId);
 
 signals:
     void windowAdded(QVariant window);

--- a/plugins/compositor/compositorwindow.cpp
+++ b/plugins/compositor/compositorwindow.cpp
@@ -22,15 +22,15 @@
 namespace luna
 {
 
-CompositorWindow::CompositorWindow(unsigned int id, QWaylandSurface *surface, QQuickItem *parent)
+CompositorWindow::CompositorWindow(unsigned int winId, QWaylandSurface *surface, QQuickItem *parent)
     : QWaylandSurfaceItem(surface, parent),
-      mId(id),
+      mId(winId),
       mClosed(false),
       mRemovePosted(false)
 {
 }
 
-unsigned int CompositorWindow::id() const
+unsigned int CompositorWindow::winId() const
 {
     return mId;
 }

--- a/plugins/compositor/compositorwindow.h
+++ b/plugins/compositor/compositorwindow.h
@@ -27,12 +27,12 @@ namespace luna
 class CompositorWindow : public QWaylandSurfaceItem
 {
     Q_OBJECT
-    Q_PROPERTY(int id READ id CONSTANT)
+    Q_PROPERTY(int winId READ winId CONSTANT)
 
 public:
-    CompositorWindow(unsigned int id, QWaylandSurface *surface, QQuickItem *parent = 0);
+    CompositorWindow(unsigned int winId, QWaylandSurface *surface, QQuickItem *parent = 0);
 
-    unsigned int id() const;
+    unsigned int winId() const;
 
     void setClosed(bool closed);
     void tryRemove();


### PR DESCRIPTION
...m the "id" property of QtQuick "Item" object.

Signed-off-by: Christophe Chapuis chris.chapuis@gmail.com
