### PR TITLE
Windows are not always unmapped when they are destroyed: make sure we re...

### DIFF
--- a/plugins/compositor/compositor.cpp
+++ b/plugins/compositor/compositor.cpp
@@ -163,6 +163,8 @@ void Compositor::surfaceAboutToBeDestroyed(QWaylandSurface *surface)
         setFullscreenSurface(0);
 
     if (window) {
+        WindowModel::removeWindowForEachModel(mWindowModels, window);
+
         mWindows.remove(window->winId());
         emit windowRemoved(QVariant::fromValue(static_cast<QQuickItem*>(window)));
 

--- a/plugins/compositor/windowmodel.cpp
+++ b/plugins/compositor/windowmodel.cpp
@@ -77,18 +77,15 @@ void WindowModel::addWindowForEachModel(QList<WindowModel*> windowModels, Compos
 {
     if( !window ) return;
 
-    foreach (WindowModel *model, windowModels)
-    {
+    foreach (WindowModel *model, windowModels) {
         if( window->windowType() == model->mWindowTypeFilter )
             model->beginInsertRows(QModelIndex(), model->mWindows.count(), model->mWindows.count());
     }
-    foreach (WindowModel *model, windowModels)
-    {
+    foreach (WindowModel *model, windowModels) {
         if( window->windowType() == model->mWindowTypeFilter )
             model->mWindows.append(window->winId());
     }
-    foreach (WindowModel *model, windowModels)
-    {
+    foreach (WindowModel *model, windowModels) {
         if( window->windowType() == model->mWindowTypeFilter )
             model->endInsertRows();
     }
@@ -99,22 +96,18 @@ void WindowModel::removeWindowForEachModel(QList<WindowModel*> windowModels, Com
     if( !window ) return;
 
     QList<WindowModel*> impactedWindowModels;
-    foreach (WindowModel *model, windowModels)
-    {
+    foreach (WindowModel *model, windowModels) {
         int index = model->mWindows.indexOf(window->winId());
-        if( window->windowType() == model->mWindowTypeFilter && index != -1 )
-        {
+        if( window->windowType() == model->mWindowTypeFilter && index != -1 ) {
             impactedWindowModels.append(model);
             model->beginRemoveRows(QModelIndex(), index, index);
         }
     }
-    foreach (WindowModel *model, impactedWindowModels)
-    {
+    foreach (WindowModel *model, impactedWindowModels) {
         int index = model->mWindows.indexOf(window->winId());
         model->mWindows.removeAt(index);
     }
-    foreach (WindowModel *model, impactedWindowModels)
-    {
+    foreach (WindowModel *model, impactedWindowModels) {
         model->endRemoveRows();
     }
 }


### PR DESCRIPTION
...move the window from the window models also in SurfaceAboutToBeDestroyed.

Note: this means that when unmapped is called before SurfaceAboutToBeDestroyed, we will try to remove the window twice from the models.

Signed-off-by: Christophe Chapuis chris.chapuis@gmail.com
