### PR TITLE
files: systemd: require LunaAppManager to be started before us

### DIFF
--- a/files/systemd/luna-next.service
+++ b/files/systemd/luna-next.service
@@ -2,7 +2,7 @@
 Description=The Luna Next UI
 Conflicts=getty@tty1.service
 Requires=ls-hubd_private.service ls-hubd_public.service
-After=ls-hubd_private.service ls-hubd_public.service LunaSysMgr.service
+After=ls-hubd_private.service ls-hubd_public.service LunaSysMgr.service LunaAppManager.service
 
 [Service]
 Type=notify


### PR DESCRIPTION
Signed-off-by: Simon Busch morphis@gravedo.de
