### PR TITLE
Implement device key handler item

### DIFF
--- a/plugins/shell/CMakeLists.txt
+++ b/plugins/shell/CMakeLists.txt
@@ -7,7 +7,8 @@ include_directories(
 set(SOURCES
     plugin.cpp
     reticleitem.cpp
-    fpscounter.cpp)
+    fpscounter.cpp
+    devicekeyhandler.cpp)
 
 add_library(lunanext-shell-qml SHARED ${SOURCES})
 qt5_use_modules(lunanext-shell-qml Qml Quick)

--- a/plugins/shell/devicekeyhandler.cpp
+++ b/plugins/shell/devicekeyhandler.cpp
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2014 Simon Busch <morphis@gravedo.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ */
+
+#include <QGuiApplication>
+#include <QKeyEvent>
+#include <QDebug>
+
+#include "devicekeyhandler.h"
+
+namespace luna
+{
+
+DeviceKeyHandler::DeviceKeyHandler(QObject *parent) :
+    QObject(parent)
+{
+    qApp->installEventFilter(this);
+}
+
+bool DeviceKeyHandler::eventFilter(QObject *, QEvent *event)
+{
+    if (event->type() == QEvent::KeyPress) {
+        QKeyEvent *keyEvent = static_cast<QKeyEvent *>(event);
+
+        switch (keyEvent->key()) {
+        case  Qt::Key_VolumeUp:
+            emit volumeUpPressed();
+            break;
+        case Qt::Key_VolumeDown:
+            emit volumeDownPressed();
+            break;
+        case Qt::Key_Home:
+            emit homePressed();
+            break;
+        case Qt::Key_Left:
+            emit leftPressed();
+            break;
+        case Qt::Key_Right:
+            emit rightPressed();
+            break;
+        case Qt::Key_Escape:
+            emit escapePressed();
+            break;
+        case Qt::Key_End:
+            emit endPressed();
+        default:
+            break;
+        }
+    }
+    return false;
+}
+
+} // namespace luna

--- a/plugins/shell/devicekeyhandler.h
+++ b/plugins/shell/devicekeyhandler.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2014 Simon Busch <morphis@gravedo.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ */
+
+#ifndef DEVICEKEYHANDLER_H
+#define DEVICEKEYHANDLER_H
+
+#include <QObject>
+
+namespace luna
+{
+
+class DeviceKeyHandler : public QObject
+{
+    Q_OBJECT
+public:
+    explicit DeviceKeyHandler(QObject *parent = 0);
+
+    virtual bool eventFilter(QObject *watched, QEvent *event);
+
+signals:
+    void volumeUpPressed();
+    void volumeDownPressed();
+    void homePressed();
+    void leftPressed();
+    void rightPressed();
+    void escapePressed();
+    void endPressed();
+};
+
+} // namespace luna
+
+#endif // DEVICEKEYHANDLER_H

--- a/plugins/shell/plugin.cpp
+++ b/plugins/shell/plugin.cpp
@@ -20,6 +20,7 @@
 #include "plugin.h"
 #include "reticleitem.h"
 #include "fpscounter.h"
+#include "devicekeyhandler.h"
 
 LunaNextShellPlugin::LunaNextShellPlugin(QObject *parent) :
     QQmlExtensionPlugin(parent)
@@ -31,6 +32,7 @@ void LunaNextShellPlugin::registerTypes(const char *uri)
     Q_ASSERT(uri == QLatin1String("LunaNext.Shell"));
     qmlRegisterType<luna::ReticleItem>(uri, 0, 1, "Reticle");
     qmlRegisterType<luna::FpsCounter>(uri, 0, 1, "FpsCounter");
+    qmlRegisterType<luna::DeviceKeyHandler>(uri, 0, 1, "DeviceKeyHandler");
 }
 
 void LunaNextShellPlugin::initializeEngine(QQmlEngine *engine, const char *uri)


### PR DESCRIPTION
The device key handler will break through the QML item hiearchy and will expose key events
to every item regardless if it gets the key events forwarded by another item or not.

Signed-off-by: Simon Busch morphis@gravedo.de
