### PR TITLE
Implement reticle handler item

### DIFF
--- a/plugins/shell/CMakeLists.txt
+++ b/plugins/shell/CMakeLists.txt
@@ -8,6 +8,7 @@ set(SOURCES
     plugin.cpp
     reticleitem.cpp
     fpscounter.cpp
+    reticlehandler.cpp
     devicekeyhandler.cpp)
 
 add_library(lunanext-shell-qml SHARED ${SOURCES})

--- a/plugins/shell/plugin.cpp
+++ b/plugins/shell/plugin.cpp
@@ -21,6 +21,7 @@
 #include "reticleitem.h"
 #include "fpscounter.h"
 #include "devicekeyhandler.h"
+#include "reticlehandler.h"
 
 LunaNextShellPlugin::LunaNextShellPlugin(QObject *parent) :
     QQmlExtensionPlugin(parent)
@@ -33,6 +34,7 @@ void LunaNextShellPlugin::registerTypes(const char *uri)
     qmlRegisterType<luna::ReticleItem>(uri, 0, 1, "Reticle");
     qmlRegisterType<luna::FpsCounter>(uri, 0, 1, "FpsCounter");
     qmlRegisterType<luna::DeviceKeyHandler>(uri, 0, 1, "DeviceKeyHandler");
+    qmlRegisterType<luna::ReticleHandler>(uri, 0, 1, "ReticleHandler");
 }
 
 void LunaNextShellPlugin::initializeEngine(QQmlEngine *engine, const char *uri)

--- a/plugins/shell/reticlehandler.cpp
+++ b/plugins/shell/reticlehandler.cpp
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2014 Simon Busch <morphis@gravedo.de>
+ * Copyright (C) 2014 Nikolay Nizov <nizovn@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ */
+
+#include <QGuiApplication>
+#include <QTouchEvent>
+
+#include "reticlehandler.h"
+
+namespace luna
+{
+
+ReticleHandler::ReticleHandler(QQuickItem *parent) :
+	QQuickItem(parent)
+{
+	qApp->installEventFilter(this);
+}
+
+bool ReticleHandler::eventFilter(QObject *, QEvent *event)
+{
+	static bool show = true;
+	switch (event->type()) {
+	case QEvent::TouchBegin:
+		show = true;
+		break;
+	case QEvent::TouchUpdate:
+		show = false;
+		break;
+	case QEvent::TouchCancel:
+		show = false;
+		break;
+	case QEvent::TouchEnd:
+		{
+			if (show) {
+				QTouchEvent *touchEvent = static_cast<QTouchEvent *>(event);
+				const QTouchEvent::TouchPoint &touchPoint = touchEvent->touchPoints().first();
+				QPointF fpoint = touchPoint.pos();
+				int x = static_cast<int>(fpoint.x());
+				int y = static_cast<int>(fpoint.y());
+				QPoint point(x,y);
+				emit reticleEvent(point);
+			};
+			show = false;
+		}
+		break;
+	}
+	return false;
+}
+
+} // namespace luna

--- a/plugins/shell/reticlehandler.h
+++ b/plugins/shell/reticlehandler.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2014 Simon Busch <morphis@gravedo.de>
+ * Copyright (C) 2014 Nikolay Nizov <nizovn@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ */
+
+#ifndef RETICLEHANDLER_H
+#define RETICLEHANDLER_H
+
+#include <QQuickItem>
+
+namespace luna
+{
+
+class ReticleHandler : public QQuickItem
+{
+	Q_OBJECT
+public:
+	explicit ReticleHandler(QQuickItem *parent = 0);
+
+	virtual bool eventFilter(QObject *watched, QEvent *event);
+
+signals:
+	void reticleEvent(QPoint pos);
+};
+
+} // namespace luna
+
+#endif // RETICLEHANDLER_H


### PR DESCRIPTION
The reticle handler item will let reticle to respect swipe gestures.(Bug #433)
This is necessary to react on release events with ability to propagate mouseMove events.

Signed-off-by: Nikolay Nizov nizovn@gmail.com
