### PR TITLE
CompositorWindow: rename a shadowing variable

### DIFF
--- a/plugins/compositor/compositorwindow.cpp
+++ b/plugins/compositor/compositorwindow.cpp
@@ -164,11 +164,11 @@ void CompositorWindow::postEvent(EventType::Event event)
     if (key > 0) {
         QWaylandInputDevice *inputDevice = surface()->compositor()->defaultInputDevice();
 
-        QKeyEvent *event = new QKeyEvent(QEvent::KeyPress, key, Qt::NoModifier);
-        inputDevice->sendFullKeyEvent(surface(), event);
+        QKeyEvent *keyEvent = new QKeyEvent(QEvent::KeyPress, key, Qt::NoModifier);
+        inputDevice->sendFullKeyEvent(surface(), keyEvent);
 
-        event = new QKeyEvent(QEvent::KeyRelease, key, Qt::NoModifier);
-        inputDevice->sendFullKeyEvent(surface(), event);
+        keyEvent = new QKeyEvent(QEvent::KeyRelease, key, Qt::NoModifier);
+        inputDevice->sendFullKeyEvent(surface(), keyEvent);
     }
 }
 


### PR DESCRIPTION
Signed-off-by: Christophe Chapuis chris.chapuis@gmail.com
