### PR TITLE
Qt 5.5 migration: Add a default output at compositor creation

### DIFF
--- a/plugins/compositor/compositor.cpp
+++ b/plugins/compositor/compositor.cpp
@@ -41,6 +41,7 @@ Compositor::Compositor()
     setColor(Qt::black);
     setRetainedSelectionEnabled(true);
     addDefaultShell();
+    createOutput(this, "", "");
 
     if (mInstance)
         qFatal("Compositor: Only one compositor instance per process is supported");


### PR DESCRIPTION
Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>