### PR TITLE
Fix launchParams to be compatible with legacy

### DIFF
--- a/plugins/shell/notifications/notification.cpp
+++ b/plugins/shell/notifications/notification.cpp
@@ -18,12 +18,12 @@
 #include "notificationmanager.h"
 #include "notification.h"
 
-Notification::Notification(const QString &ownerId, uint replacesId, const QString &launchId, const QString &launchParam, const QString &title, const QString &body, const QUrl &iconUrl, const QString &soundClass, const QUrl &soundFile, int duration, bool doNotSuppress, int priority, int expireTimeout, QObject *parent) :
+Notification::Notification(const QString &ownerId, uint replacesId, const QString &launchId, const QString &launchParams, const QString &title, const QString &body, const QUrl &iconUrl, const QString &soundClass, const QUrl &soundFile, int duration, bool doNotSuppress, int priority, int expireTimeout, QObject *parent) :
     QObject(parent),
     ownerId_(ownerId),
     replacesId_(replacesId),
     launchId_(launchId),
-    launchParam_(launchParam),
+    launchParams_(launchParams),
     title_(title),
     body_(body),
     iconUrl_(iconUrl),
@@ -50,6 +50,7 @@ Notification::Notification(const Notification &notification) :
     ownerId_(notification.ownerId_),
     replacesId_(notification.replacesId_),
     launchId_(notification.launchId_),
+	launchParams_(notification.launchParams_),
     title_(notification.title_),
     body_(notification.body_),
     iconUrl_(notification.iconUrl_),
@@ -88,14 +89,14 @@ void Notification::setLaunchId(const QString &launchId)
     launchId_ = launchId;
 }
 
-QString Notification::launchParam() const
+QString Notification::launchParams() const
 {
-    return launchParam_;
+    return launchParams_;
 }
 
-void Notification::setLaunchParam(const QString &launchParam)
+void Notification::setLaunchParams(const QString &launchParams)
 {
-    launchParam_ = launchParam;
+    launchParams_ = launchParams;
 }
 
 QString Notification::title() const

--- a/plugins/shell/notifications/notification.h
+++ b/plugins/shell/notifications/notification.h
@@ -30,7 +30,7 @@ class Notification : public QObject
     Q_PROPERTY(QString ownerId READ ownerId)
     Q_PROPERTY(uint replacesId READ replacesId)
     Q_PROPERTY(QString launchId READ launchId)
-    Q_PROPERTY(QString launchParam READ launchParam)
+    Q_PROPERTY(QString launchParams READ launchParams)
     Q_PROPERTY(QString title READ title NOTIFY titleChanged)
     Q_PROPERTY(QString body READ body NOTIFY bodyChanged)
     Q_PROPERTY(QUrl iconUrl READ iconUrl NOTIFY iconUrlChanged)
@@ -49,7 +49,7 @@ public:
      * \param ownerId name of the or application/service sending the notification
      * \param replacesID the ID of the notification
      * \param launchId can default to ownerId, but allowed to be freely set in general for services and apps
-     * \param launchParam parameters supplied to app when (re-)launched because user clicked on the notification
+     * \param launchParams parameters supplied to app when (re-)launched because user clicked on the notification
      * \param title title text for the notification, no markup
      * \param body body text for the notification, should use some markup
      * \param iconUrl icon url for the notification, only local urls (file://) are allowed
@@ -61,7 +61,7 @@ public:
      * \param expireTimeout expiration timeout for the notification
      * \param parent the parent QObject
      */
-    Notification(const QString &ownerId, uint replacesId, const QString &launchId, const QString &launchParam, const QString &title, const QString &body, const QUrl &iconUrl, const QString &soundClass, const QUrl &soundFile, int duration, bool doNotSuppress, int priority, int expireTimeout, QObject *parent = 0);
+    Notification(const QString &ownerId, uint replacesId, const QString &launchId, const QString &launchParams, const QString &title, const QString &body, const QUrl &iconUrl, const QString &soundClass, const QUrl &soundFile, int duration, bool doNotSuppress, int priority, int expireTimeout, QObject *parent = 0);
 
     /*!
      * Creates a new uninitialized representation of a notification.
@@ -86,10 +86,10 @@ public:
     void setLaunchId(const QString &launchId);
 
     //! Returns the parameters that are associated to the action on the notification
-    QString launchParam() const;
+    QString launchParams() const;
 
     //! Sets the parameters that are associated to the action on the notification
-    void setLaunchParam(const QString &launchParam);
+    void setLaunchParams(const QString &launchParams);
 
     //! Returns the title text for the notification
     QString title() const;
@@ -208,7 +208,7 @@ private:
     QString launchId_;
 
     //! parameters associated to an action on the notification
-    QString launchParam_;
+    QString launchParams_;
 
     //! Title text for the notification
     QString title_;

--- a/plugins/shell/notifications/notificationmanager.h
+++ b/plugins/shell/notifications/notificationmanager.h
@@ -79,7 +79,7 @@ public:
      * \param ownerId name of the or application/service sending the notification
      * \param replacesID the ID of the notification
      * \param launchId can default to ownerId, but allowed to be freely set in general for services and apps
-     * \param launchParam parameters supplied to app when (re-)launched because user clicked on the notification
+     * \param launchParams parameters supplied to app when (re-)launched because user clicked on the notification
      * \param title title text for the notification, no markup
      * \param body body text for the notification, should use some markup
      * \param iconUrl icon url for the notification, only local urls (file://) are allowed
@@ -87,7 +87,7 @@ public:
      * \param expireTimeout expiration timeout for the notification
      * \param parent the parent QObject
      */
-    uint Notify(const QString &ownerId, uint replacesId, const QString &launchId, const QString &launchParam,
+    uint Notify(const QString &ownerId, uint replacesId, const QString &launchId, const QString &launchParams,
                 const QString &title, const QString &body, const QUrl &iconUrl, const QString &soundClass,
                 const QUrl &soundFile, int duration, bool doNotSuppress, int priority, int expireTimeout);
 

--- a/plugins/shell/notifications/notificationmanagerwrapper.cpp
+++ b/plugins/shell/notifications/notificationmanagerwrapper.cpp
@@ -23,7 +23,7 @@ Notification* NotificationManagerWrapper::getNotificationById(uint id)
     return NotificationManager::instance()->notification(id);
 }
 
-uint NotificationManagerWrapper::notify(const QString &ownerId, uint replacesId, const QString &launchId, const QString &launchParam,
+uint NotificationManagerWrapper::notify(const QString &ownerId, uint replacesId, const QString &launchId, const QString &launchParams,
                                         const QString &title, const QString &body, const QUrl &iconUrl, const QString &soundClass,
                                         const QUrl &soundFile, int duration, bool doNotSuppress, int priority, int expireTimeout)
 {

--- a/plugins/shell/notifications/notificationmanagerwrapper.h
+++ b/plugins/shell/notifications/notificationmanagerwrapper.h
@@ -27,7 +27,7 @@ public:
     NotificationManagerWrapper();
 
     Q_INVOKABLE Notification* getNotificationById(uint id);
-    Q_INVOKABLE uint notify(const QString &ownerId, uint replacesId, const QString &launchId, const QString &launchParam,
+    Q_INVOKABLE uint notify(const QString &ownerId, uint replacesId, const QString &launchId, const QString &launchParams,
                             const QString &title, const QString &body, const QUrl &iconUrl, const QString &soundClass, const QUrl &soundFile,
                             int duration, bool doNotSuppress, int priority, int expireTimeout);
     Q_INVOKABLE void closeById(uint id, NotificationManager::NotificationClosedReason reason = NotificationManager::CloseNotificationCalled);


### PR DESCRIPTION
They're called launchParams in legacy, not launchParam which caused the handling not to be correct. 