### PR TITLE
Remove unused signal

### DIFF
--- a/plugins/shell/notifications/notificationlistmodel.cpp
+++ b/plugins/shell/notifications/notificationlistmodel.cpp
@@ -23,7 +23,6 @@ NotificationListModel::NotificationListModel(QObject *parent) :
 {
     connect(NotificationManager::instance(), SIGNAL(notificationModified(uint)), this, SLOT(updateNotification(uint)));
     connect(NotificationManager::instance(), SIGNAL(notificationRemoved(uint)), this, SLOT(removeNotification(uint)));
-    connect(this, SIGNAL(clearRequested()), NotificationManager::instance(), SLOT(removeUserRemovableNotifications()));
 
     QTimer::singleShot(0, this, SLOT(init()));
 }

--- a/plugins/shell/notifications/notificationlistmodel.h
+++ b/plugins/shell/notifications/notificationlistmodel.h
@@ -28,9 +28,6 @@ public:
     explicit NotificationListModel(QObject *parent = 0);
     virtual ~NotificationListModel();
 
-signals:
-    void clearRequested();
-
 private slots:
     void init();
     void updateNotification(uint id);


### PR DESCRIPTION
Should solve the following warnings in log:

Sep 20 08:20:27 mako luna-next[1242]: WARNING: 08:20:27.849: QObject::connect: No such slot NotificationManager::removeUserRemovableNotifications() 

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>