### PR TITLE
compositor: add a default output mode

### DIFF
--- a/plugins/compositor/compositor.cpp
+++ b/plugins/compositor/compositor.cpp
@@ -67,6 +67,12 @@ void Compositor::create()
 
     QWaylandCompositor::create();
 
+    // Add a valid mode for the output
+    QWaylandOutput *output = defaultOutput();
+    QWaylandOutputMode defaultMode(QSize(output->window()->size()), 25000);
+    output->addMode(defaultMode, true);
+    output->setCurrentMode(defaultMode);
+
     QWaylandWlShell *wlShell = new QWaylandWlShell(this);
     connect(wlShell, &QWaylandWlShell::wlShellSurfaceCreated, this, &Compositor::onWlShellSurfaceCreated);
 


### PR DESCRIPTION
This will ensure that a valid mode exists for this output.
Otherwise the compositor will return a screen of null geometry,
leading to issues with height in the Enyo popup windows.