### PR TITLE
compositor: use QtKeyExtensionGlobal

### DIFF
--- a/plugins/compositor/compositor.cpp
+++ b/plugins/compositor/compositor.cpp
@@ -27,6 +27,8 @@
 #include <QWaylandWlShell>
 #include <QWaylandWlShellSurface>
 
+#include "QtWaylandCompositor/private/qwlqtkey_p.h"
+
 namespace luna
 {
 
@@ -83,6 +85,8 @@ void Compositor::create()
 
     mSurfaceExtension = new QtWayland::SurfaceExtensionGlobal(this);
     connect(mSurfaceExtension, &QtWayland::SurfaceExtensionGlobal::extendedSurfaceReady, this, &Compositor::onExtendedSurfaceReady);
+
+    QtWayland::QtKeyExtensionGlobal *pKeyExtension = new QtWayland::QtKeyExtensionGlobal(this);
 
     mRecorder = new RecorderManager(this);
 }

--- a/plugins/compositor/compositorwindow.cpp
+++ b/plugins/compositor/compositorwindow.cpp
@@ -233,10 +233,10 @@ void CompositorWindow::postEvent(int event)
     if (key > 0) {
         QWaylandSeat *defaultSeat = surface()->compositor()->defaultSeat();
 
-        QKeyEvent *keyEvent = new QKeyEvent(QEvent::KeyPress, key, Qt::NoModifier);
+        QKeyEvent *keyEvent = new QKeyEvent(QEvent::KeyPress, key, Qt::NoModifier, key, 0, 0);
         defaultSeat->sendFullKeyEvent(keyEvent);
 
-        keyEvent = new QKeyEvent(QEvent::KeyRelease, key, Qt::NoModifier);
+        keyEvent = new QKeyEvent(QEvent::KeyRelease, key, Qt::NoModifier, key, 0, 0);
         defaultSeat->sendFullKeyEvent(keyEvent);
     }
 }


### PR DESCRIPTION
This experimental QtWayland extension lets us send more easily
Qt key strokes, without needing to set the native key code.

The native code is nevertheless set in CompositorWindow::postEvent,
so that the code still works if xkbcommon-evdev is absent.

Depends on https://github.com/webOS-ports/meta-webos-ports/pull/250

Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>