### PR TITLE
Compositor: use a ManualFocus policy

### DIFF
--- a/plugins/compositor/compositor.cpp
+++ b/plugins/compositor/compositor.cpp
@@ -76,6 +76,7 @@ void Compositor::create()
     output->setCurrentMode(defaultMode);
 
     QWaylandWlShell *wlShell = new QWaylandWlShell(this);
+    wlShell->setFocusPolicy(QWaylandShell::ManualFocus);
     connect(wlShell, &QWaylandWlShell::wlShellSurfaceCreated, this, &Compositor::onWlShellSurfaceCreated);
 
     connect(this, &QWaylandCompositor::surfaceCreated, this, &Compositor::onSurfaceCreated);


### PR DESCRIPTION
Using the default AutomaticFocus policy of the QtWayland shell leads to
focus issue depending on the order of the discovery of the inputs.

Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>