### PR TITLE
Qt 5.12 migrations

### DIFF
--- a/plugins/compositor/compositor.cpp
+++ b/plugins/compositor/compositor.cpp
@@ -29,6 +29,7 @@
 #include <QWaylandXdgToplevel>
 
 #include "QtWaylandCompositor/private/qwlqtkey_p.h"
+#include <QtWaylandCompositor/QWaylandXdgDecorationManagerV1>
 
 namespace luna
 {
@@ -90,6 +91,11 @@ void Compositor::create()
     connect(mSurfaceExtension, &QtWayland::SurfaceExtensionGlobal::extendedSurfaceReady, this, &Compositor::onExtendedSurfaceReady);
 
     QtWayland::QtKeyExtensionGlobal *pKeyExtension = new QtWayland::QtKeyExtensionGlobal(this);
+
+    QWaylandXdgDecorationManagerV1 *mXdgDecorationManagerV1 = new QWaylandXdgDecorationManagerV1();
+    mXdgDecorationManagerV1->setExtensionContainer(this);
+    mXdgDecorationManagerV1->initialize();
+    mXdgDecorationManagerV1->setPreferredMode(QWaylandXdgToplevel::ServerSideDecoration);
 
     mRecorder = new RecorderManager(this);
 }

--- a/plugins/compositor/compositor.h
+++ b/plugins/compositor/compositor.h
@@ -20,7 +20,7 @@
 
 #include <QWaylandQuickCompositor>
 #include <QWaylandSurface>
-#include <QWaylandWlShellSurface>
+#include <QWaylandXdgSurface>
 #include <QWaylandClient>
 #include <QtWaylandCompositor/private/qwlextendedsurface_p.h>
 
@@ -87,7 +87,8 @@ private slots:
     void onSurfaceAboutToBeDestroyed(QWaylandSurface *surface);
     void windowIsReady();
 
-    void onWlShellSurfaceCreated(QWaylandWlShellSurface *shellSurface);
+    //void onXdgSurfaceCreated(QWaylandXdgSurface *shellSurface);
+    void onXdgToplevelCreated(QWaylandXdgToplevel *toplevel, QWaylandXdgSurface *shellSurface);
     void onExtendedSurfaceReady(QtWayland::ExtendedSurface *extSurface, QWaylandSurface *surface);
 
 private:

--- a/plugins/compositor/compositorwindow.cpp
+++ b/plugins/compositor/compositorwindow.cpp
@@ -20,7 +20,8 @@
 
 #include <QWaylandCompositor>
 #include <QWaylandSeat>
-#include <QWaylandWlShellSurface>
+#include <QWaylandXdgSurface>
+#include <QWaylandXdgToplevel>
 
 #include <QtWaylandCompositor/private/qwlextendedsurface_p.h>
 
@@ -51,16 +52,16 @@ CompositorWindow::~CompositorWindow()
     qDebug() << Q_FUNC_INFO << "id" << mId << "type" << mWindowType << "appId" << mAppId;
 }
 
-void CompositorWindow::initialize(QWaylandWlShellSurface *shellSurface)
+void CompositorWindow::initialize(QWaylandXdgSurface *shellSurface)
 {
     setShellSurface(shellSurface);
 
     QWaylandSurface *surface = shellSurface->surface();
-    setSurface(surface);
+    if(surface) setSurface(surface);
 
     connect(this, &QWaylandQuickItem::surfaceDestroyed, this, &QObject::deleteLater);
     connect(surface, &QWaylandSurface::hasContentChanged, this, &CompositorWindow::onSurfaceMappedChanged);
-    connect(shellSurface, &QWaylandWlShellSurface::windowTypeChanged, this, &CompositorWindow::onWindowTypeChanged);
+    connect(shellSurface, &QWaylandShellSurface::windowTypeChanged, this, &CompositorWindow::onWindowTypeChanged);
 }
 
 void CompositorWindow::forceVisible()
@@ -243,9 +244,15 @@ void CompositorWindow::postEvent(int event)
 
 void CompositorWindow::changeSize(const QSize& size)
 {
-    QWaylandWlShellSurface *pWlShellSurfaceExt = static_cast<QWaylandWlShellSurface*>(shellSurface());
-    if(pWlShellSurfaceExt)
-        pWlShellSurfaceExt->sendConfigure(size, QWaylandWlShellSurface::BottomRightEdge);
+    QWaylandXdgSurface *pXdgShellSurfaceExt = static_cast<QWaylandXdgSurface*>(shellSurface());
+    QWaylandXdgToplevel *pXdgTopLevel = NULL;
+    if(pXdgShellSurfaceExt) pXdgTopLevel = pXdgShellSurfaceExt->toplevel();
+    
+    if(pXdgTopLevel)
+    {
+        QVector<QWaylandXdgToplevel::State> states;
+        pXdgTopLevel->sendConfigure(size, states);
+    }
 }
 
 void CompositorWindow::setParentWinId(unsigned int id)

--- a/plugins/compositor/compositorwindow.h
+++ b/plugins/compositor/compositorwindow.h
@@ -26,6 +26,8 @@
 #include "eventtype.h"
 #include "windowtype.h"
 
+class QWaylandXdgSurface;
+
 namespace luna
 {
 
@@ -49,7 +51,7 @@ public:
     CompositorWindow(unsigned int winId, QQuickItem *parent = 0);
     virtual ~CompositorWindow();
 
-    void initialize(QWaylandWlShellSurface *shellSurface);
+    void initialize(QWaylandXdgSurface *shellSurface);
 
     unsigned int winId() const;
     unsigned int parentWinId() const;


### PR DESCRIPTION
* Stop using deprecated WlShell extension, and swtich to XdgShell
* Use QWaylandXdgDecorationManagerV1 extension instead of deprecated QT_WAYLAND_DISABLE_WINDOWDECORATION env. variable. Also this one solves an issue with black surfaces on qemu targets with Qt 5.12.