### PR TITLE
Compositor: ExtendedSurface is now managed in window's initialize

### DIFF
--- a/plugins/compositor/compositor.cpp
+++ b/plugins/compositor/compositor.cpp
@@ -313,28 +313,13 @@ void Compositor::onXdgToplevelCreated(QWaylandXdgToplevel *toplevel, QWaylandXdg
 
     connect(window, &CompositorWindow::readyChanged, this, &Compositor::windowIsReady);
     connect(window, &QWaylandQuickItem::surfaceDestroyed, this, &Compositor::onSurfaceDestroyed);
+
+    window->sendWindowIdToClient();
 }
 
 void Compositor::onExtendedSurfaceReady(QtWayland::ExtendedSurface *extSurface, QWaylandSurface *surface)
 {
     extSurface->initialize();
-
-    CompositorWindow *window = surfaceWindow(surface);
-    if (window)
-    {
-        QVariantMap properties = extSurface->windowProperties();
-        QMapIterator<QString,QVariant> iter(properties);
-        while (iter.hasNext()) {
-            iter.next();
-            window->onWindowPropertyChanged(iter.key(), iter.value());
-        }
-
-        connect(extSurface, &QtWayland::ExtendedSurface::windowPropertyChanged, window, &CompositorWindow::onWindowPropertyChanged);
-        connect(extSurface, &QtWayland::ExtendedSurface::raiseRequested, this, &Compositor::onSurfaceRaised);
-        connect(extSurface, &QtWayland::ExtendedSurface::lowerRequested, this, &Compositor::onSurfaceLowered);
-
-        window->sendWindowIdToClient();
-    }
 }
 
 void Compositor::setRecording(bool value)

--- a/plugins/compositor/compositorwindow.cpp
+++ b/plugins/compositor/compositorwindow.cpp
@@ -57,7 +57,22 @@ void CompositorWindow::initialize(QWaylandXdgSurface *shellSurface)
     setShellSurface(shellSurface);
 
     QWaylandSurface *surface = shellSurface->surface();
-    if(surface) setSurface(surface);
+    if(surface) {
+        setSurface(surface);
+
+        QtWayland::ExtendedSurface *extSurface = static_cast<QtWayland::ExtendedSurface*>(surface->extension(QtWayland::ExtendedSurface::interfaceName()));
+        if (extSurface)
+        {
+            QVariantMap properties = extSurface->windowProperties();
+            QMapIterator<QString,QVariant> iter(properties);
+            while (iter.hasNext()) {
+                iter.next();
+                onWindowPropertyChanged(iter.key(), iter.value());
+            }
+
+            connect(extSurface, &QtWayland::ExtendedSurface::windowPropertyChanged, this, &CompositorWindow::onWindowPropertyChanged);
+        }
+    }
 
     connect(this, &QWaylandQuickItem::surfaceDestroyed, this, &QObject::deleteLater);
     connect(surface, &QWaylandSurface::hasContentChanged, this, &CompositorWindow::onSurfaceMappedChanged);


### PR DESCRIPTION
With XdgShell, the ExtendedSurface is ready before the shell surface
gets created.

Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>