### PR TITLE
Add additional permissions for org.webosports.luna

### DIFF
--- a/files/sysbus/org.webosports.luna.perm.json
+++ b/files/sysbus/org.webosports.luna.perm.json
@@ -4,7 +4,9 @@
         "devices",
         "services",
         "settings",
-        "system"
+        "system",
+        "media",
+        "all"        
     ],
     "org.webosports.notifications": [
         "applications",


### PR DESCRIPTION
Solves:
Adding "media" solves: 2020-05-17T13:41:07.006419Z [13.400317704] user.warning audio-service [] <default-lib> LS_REQUIRES_SECURITY {"SERVICE":"org.webosports.luna","CATEGORY":"/","METHOD":"getStatus"} Service security groups don't allow method call.

Adding "all" solves: 2020-05-17T16:33:33.825257Z [15.219016511] user.warning ports.service.tweaks.prefs [] <default-lib> LS_REQUIRES_SECURITY {"SERVICE":"org.webosports.luna","CATEGORY":"/","METHOD":"get"} Service security groups don't allow method call.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>