### PR TITLE
main.cpp: Set QML_XHR_ALLOW_FILE_READ environment variable

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -123,6 +123,9 @@ int main(int argc, char *argv[])
 
     mkdir(XDG_RUNTIME_DIR_DEFAULT, 0700);
     setenv("XDG_RUNTIME_DIR", XDG_RUNTIME_DIR_DEFAULT, 0);
+    
+    // We want to make sure we can still use XHR for loading local files at our end in our QML apps.
+    qputenv("QML_XHR_ALLOW_FILE_READ", QByteArray("1"));
 
     QString shellName = qgetenv("LUNA_NEXT_SHELL");
     if (shellName.isEmpty())


### PR DESCRIPTION
So we can keep loading local files in newer Qt. 

Solves: "XMLHttpRequest: Using GET on a local file is dangerous and will be disabled by default in a future Qt version. Set QML_XHR_ALLOW_FILE_READ to 1 if you wish to continue using this feature."

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>